### PR TITLE
Implement ToTargetAddr for more

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,7 @@ impl<'a> IntoTargetAddr<'a> for (&'a str, u16) {
         }
 
         // Treat as domain name
-        let len = self.0.as_bytes().len();
-        if len > 255 {
+        if self.0.len() > 255 {
             return Err(Error::InvalidTargetAddress("overlong domain"));
         }
         // TODO: Should we validate the domain format here?
@@ -193,6 +192,9 @@ impl<'a> IntoTargetAddr<'a> for &'a str {
         let domain = parts_iter
             .next()
             .ok_or(Error::InvalidTargetAddress("invalid address format"))?;
+        if domain.len() > 255 {
+            return Err(Error::InvalidTargetAddress("overlong domain"));
+        }
         Ok(TargetAddr::Domain(domain.into(), port))
     }
 }
@@ -213,6 +215,9 @@ impl IntoTargetAddr<'static> for String {
             .next()
             .ok_or(Error::InvalidTargetAddress("invalid address format"))?
             .len();
+        if domain_len > 255 {
+            return Err(Error::InvalidTargetAddress("overlong domain"));
+        }
         self.truncate(domain_len);
         Ok(TargetAddr::Domain(self.into(), port))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,12 @@ trivial_impl_into_target_addr!((Ipv6Addr, u16));
 trivial_impl_into_target_addr!(SocketAddrV4);
 trivial_impl_into_target_addr!(SocketAddrV6);
 
+impl<'a> IntoTargetAddr<'a> for TargetAddr<'a> {
+    fn into_target_addr(self) -> Result<TargetAddr<'a>> {
+        Ok(self)
+    }
+}
+
 impl<'a> IntoTargetAddr<'a> for (&'a str, u16) {
     fn into_target_addr(self) -> Result<TargetAddr<'a>> {
         // Try IP address first
@@ -187,7 +193,28 @@ impl<'a> IntoTargetAddr<'a> for &'a str {
         let domain = parts_iter
             .next()
             .ok_or(Error::InvalidTargetAddress("invalid address format"))?;
-        (domain, port).into_target_addr()
+        Ok(TargetAddr::Domain(domain.into(), port))
+    }
+}
+
+impl IntoTargetAddr<'static> for String {
+    fn into_target_addr(mut self) -> Result<TargetAddr<'static>> {
+        // Try IP address first
+        if let Ok(addr) = self.parse::<SocketAddr>() {
+            return addr.into_target_addr();
+        }
+
+        let mut parts_iter = self.rsplitn(2, ':');
+        let port: u16 = parts_iter
+            .next()
+            .and_then(|port_str| port_str.parse().ok())
+            .ok_or(Error::InvalidTargetAddress("invalid address format"))?;
+        let domain_len = parts_iter
+            .next()
+            .ok_or(Error::InvalidTargetAddress("invalid address format"))?
+            .len();
+        self.truncate(domain_len);
+        Ok(TargetAddr::Domain(self.into(), port))
     }
 }
 
@@ -315,6 +342,12 @@ mod tests {
         let res = into_target_addr(domain)?;
         assert_eq!(
             TargetAddr::Domain(Cow::Borrowed("www.example.com"), 80),
+            res
+        );
+
+        let res = into_target_addr(domain.to_owned())?;
+        assert_eq!(
+            TargetAddr::Domain(Cow::Owned("www.example.com".to_owned()), 80),
             res
         );
         Ok(())


### PR DESCRIPTION
It is now not so convenient to construct a `'static`  `SocksStream`. With this PR, if we pass in an owned `String`, we get a `'static` one.