### PR TITLE
replace failure with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ required-features=["tor"]
 futures = "0.3"
 tokio = { version="0.2", features = ["io-util", "stream", "tcp"] }
 bytes = "0.4"
-failure = "0.1"
 either = "1"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["io-util", "rt-threaded"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,76 +1,69 @@
-use failure::Fail;
-
 /// Error type of `tokio-socks`
-#[derive(Fail, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Failure caused by an IO error.
-    #[fail(display = "{}", _0)]
-    Io(#[cause] std::io::Error),
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
     /// Failure when parsing a `String`.
-    #[fail(display = "{}", _0)]
-    ParseError(#[cause] std::string::ParseError),
+    #[error("{0}")]
+    ParseError(#[from] std::string::ParseError),
     /// Failure due to invalid target address. It contains the detailed error
     /// message.
-    #[fail(display = "Target address is invalid: {}", _0)]
+    #[error("Target address is invalid: {0}")]
     InvalidTargetAddress(&'static str),
     /// Proxy server unreachable.
-    #[fail(display = "Proxy server unreachable")]
+    #[error("Proxy server unreachable")]
     ProxyServerUnreachable,
     /// Proxy server returns an invalid version number.
-    #[fail(display = "Invalid response version")]
+    #[error("Invalid response version")]
     InvalidResponseVersion,
     /// No acceptable auth methods
-    #[fail(display = "No acceptable auth methods")]
+    #[error("No acceptable auth methods")]
     NoAcceptableAuthMethods,
     /// Unknown auth method
-    #[fail(display = "Unknown auth method")]
+    #[error("Unknown auth method")]
     UnknownAuthMethod,
     /// General SOCKS server failure
-    #[fail(display = "General SOCKS server failure")]
+    #[error("General SOCKS server failure")]
     GeneralSocksServerFailure,
     /// Connection not allowed by ruleset
-    #[fail(display = "Connection not allowed by ruleset")]
+    #[error("Connection not allowed by ruleset")]
     ConnectionNotAllowedByRuleset,
     /// Network unreachable
-    #[fail(display = "Network unreachable")]
+    #[error("Network unreachable")]
     NetworkUnreachable,
     /// Host unreachable
-    #[fail(display = "Host unreachable")]
+    #[error("Host unreachable")]
     HostUnreachable,
     /// Connection refused
-    #[fail(display = "Connection refused")]
+    #[error("Connection refused")]
     ConnectionRefused,
     /// TTL expired
-    #[fail(display = "TTL expired")]
+    #[error("TTL expired")]
     TtlExpired,
     /// Command not supported
-    #[fail(display = "Command not supported")]
+    #[error("Command not supported")]
     CommandNotSupported,
     /// Address type not supported
-    #[fail(display = "Address type not supported")]
+    #[error("Address type not supported")]
     AddressTypeNotSupported,
     /// Unknown error
-    #[fail(display = "Unknown error")]
+    #[error("Unknown error")]
     UnknownError,
     /// Invalid reserved byte
-    #[fail(display = "Invalid reserved byte")]
+    #[error("Invalid reserved byte")]
     InvalidReservedByte,
     /// Unknown address type
-    #[fail(display = "Unknown address type")]
+    #[error("Unknown address type")]
     UnknownAddressType,
     /// Invalid authentication values. It contains the detailed error message.
-    #[fail(display = "Invalid auth values: {}", _0)]
+    #[error("Invalid auth values: {0}")]
     InvalidAuthValues(&'static str),
     /// Password auth failure
-    #[fail(display = "Password auth failure, code: {}", _0)]
+    #[error("Password auth failure, code: {0}")]
     PasswordAuthFailure(u8),
 }
 
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error {
-        Error::Io(err)
-    }
-}
 
 ///// Result type of `tokio-socks`
 // pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Consensus seems to be that using failure in libraries is discouraged in
in favor of using the std Error trait.

[thiserror](https://crates.io/crates/thiserror) provides the failure features used in tokio-socks while
creating an error conforming to the std Error trait.

It requires a minimum rustc version of 1.31, but the same is true for
failure, so this should not be trouble.

For people relying on the fact that `tokio_socks::Error` is `Fail` this would probably be a breaking change, but I am not sure it would be hard to fix.