### PR TITLE
Allow to take arbitrary socket instead of address to estaplish connexion to proxy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:artyom.h31/3proxy -y
           sudo apt-get update
-          sudo apt-get install 3proxy -y
+          sudo apt-get install 3proxy socat -y
       - name: Run tests
         run: |
           cargo build --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ either = "1"
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-util", "rt-threaded"] }
+tokio = { version = "0.2", features = ["io-util", "rt-threaded", "uds"] }
 once_cell = "1.2.0"
 hyper = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ either = "1"
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["io-util", "rt-threaded", "uds"] }
+tokio = { version = "0.2", features = ["io-util", "rt-threaded", "uds", "dns"] }
 once_cell = "1.2.0"
 hyper = "0.13"

--- a/examples/socket.rs
+++ b/examples/socket.rs
@@ -1,0 +1,44 @@
+//! Test the tor proxy capabilities
+//!
+//! This example requires a running tor proxy.
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpStream, UnixStream},
+    runtime::Runtime,
+};
+use tokio_socks::{tcp::Socks5Stream, Error};
+
+const UNIX_PROXY_ADDR: &str = "/tmp/tor/socket.s";
+const TCP_PROXY_ADDR: &str = "127.0.0.1:9050";
+const ONION_ADDR: &str = "3g2upl4pq6kufc4m.onion:80"; // DuckDuckGo
+
+async fn connect() -> Result<(), Error> {
+    // This require Tor to listen on and Unix Domain Socket.
+    // You have to create a directory /tmp/tor owned by tor, and for which only tor has rights, and
+    // add the following line to your torrc :
+    // SocksPort unix:/tmp/tor/socket.s
+    let socket = UnixStream::connect(UNIX_PROXY_ADDR).await?;
+    let target = Socks5Stream::tor_resolve_with_socket(socket, "duckduckgo.com:0").await?;
+    eprintln!("duckduckgo.com = {:?}", target);
+    let socket = UnixStream::connect(UNIX_PROXY_ADDR).await?;
+    let target = Socks5Stream::tor_resolve_ptr_with_socket(socket, "176.34.155.23:0").await?;
+    eprintln!("176.34.155.23 = {:?}", target);
+
+    let socket = TcpStream::connect(TCP_PROXY_ADDR).await?;
+    socket.set_nodelay(true)?;
+    let mut conn = Socks5Stream::connect_with_socket(socket, ONION_ADDR).await?;
+    conn.write_all(b"GET /\n\n").await?;
+
+    let mut buf = Vec::new();
+    let n = conn.read_to_end(&mut buf).await?;
+
+    println!("{} bytes read\n\n{}", n, String::from_utf8_lossy(&buf));
+
+    Ok(())
+}
+
+fn main() {
+    let mut rt = Runtime::new().unwrap();
+    rt.block_on(connect()).unwrap();
+}

--- a/examples/socket.rs
+++ b/examples/socket.rs
@@ -15,8 +15,8 @@ const ONION_ADDR: &str = "3g2upl4pq6kufc4m.onion:80"; // DuckDuckGo
 
 async fn connect() -> Result<(), Error> {
     // This require Tor to listen on and Unix Domain Socket.
-    // You have to create a directory /tmp/tor owned by tor, and for which only tor has rights, and
-    // add the following line to your torrc :
+    // You have to create a directory /tmp/tor owned by tor, and for which only tor
+    // has rights, and add the following line to your torrc :
     // SocksPort unix:/tmp/tor/socket.s
     let socket = UnixStream::connect(UNIX_PROXY_ADDR).await?;
     let target = Socks5Stream::tor_resolve_with_socket(socket, "duckduckgo.com:0").await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,5 @@ pub enum Error {
     PasswordAuthFailure(u8),
 }
 
-
 ///// Result type of `tokio-socks`
 // pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl Stream for ProxyAddrsStream {
             Some(Err(_)) => {
                 let err = self.0.take().unwrap().unwrap_err();
                 Poll::Ready(Some(Err(err.into())))
-            }
+            },
             None => unreachable!(),
         }
     }
@@ -235,8 +235,7 @@ impl IntoTargetAddr<'static> for (String, u16) {
 }
 
 impl<'a, T> IntoTargetAddr<'a> for &'a T
-where
-    T: IntoTargetAddr<'a> + Copy,
+where T: IntoTargetAddr<'a> + Copy
 {
     fn into_target_addr(self) -> Result<TargetAddr<'a>> {
         (*self).into_target_addr()
@@ -299,9 +298,7 @@ mod tests {
     }
 
     fn into_target_addr<'a, T>(t: T) -> Result<TargetAddr<'a>>
-    where
-        T: IntoTargetAddr<'a>,
-    {
+    where T: IntoTargetAddr<'a> {
         t.into_target_addr()
     }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -97,6 +97,8 @@ impl Socks5Stream<TcpStream> {
     }
 
     #[cfg(feature = "tor")]
+    /// Resolve the domain name to an ip using special Tor Resolve command, by connecting to a Tor
+    /// compatible proxy given it's address.
     pub async fn tor_resolve<'t, P, T>(proxy: P, target: T) -> Result<TargetAddr<'static>>
     where
         P: ToProxyAddrs,
@@ -108,6 +110,8 @@ impl Socks5Stream<TcpStream> {
     }
 
     #[cfg(feature = "tor")]
+    /// Perform a reverse DNS query on the given ip using special Tor Resolve PTR command, by connecting to a Tor
+    /// compatible proxy given it's address.
     pub async fn tor_resolve_ptr<'t, P, T>(proxy: P, target: T) -> Result<TargetAddr<'static>>
     where
         P: ToProxyAddrs,
@@ -152,8 +156,8 @@ where S: AsyncRead + AsyncWrite + Unpin
         Self::execute_command_with_socket(socket, target, Authentication::None, Command::Connect).await
     }
 
-    /// Connects to a target server through a SOCKS5 proxy using given username
-    /// , password and a socket to the proxy
+    /// Connects to a target server through a SOCKS5 proxy using given username,
+    /// password and a socket to the proxy
     ///
     /// # Error
     ///
@@ -196,6 +200,8 @@ where S: AsyncRead + AsyncWrite + Unpin
 
 
     #[cfg(feature = "tor")]
+    /// Resolve the domain name to an ip using special Tor Resolve command, by connecting to a Tor
+    /// compatible proxy given a socket to it.
     pub async fn tor_resolve_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolve).await?;
@@ -204,6 +210,8 @@ where S: AsyncRead + AsyncWrite + Unpin
     }
 
     #[cfg(feature = "tor")]
+    /// Perform a reverse DNS query on the given ip using special Tor Resolve PTR command, by connecting to a Tor
+    /// compatible proxy given a socket to it.
     pub async fn tor_resolve_ptr_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock =
@@ -570,7 +578,7 @@ impl Socks5Listener<TcpStream> {
 impl<S> Socks5Listener<S>
 where S: AsyncRead + AsyncWrite + Unpin
 {
-    /// Initiates a BIND request to the specified proxy.
+    /// Initiates a BIND request to the specified proxy using the given socket to it.
     ///
     /// The proxy will filter incoming connections based on the value of
     /// `target`.
@@ -584,8 +592,8 @@ where S: AsyncRead + AsyncWrite + Unpin
         Self::bind_with_auth_and_socket(Authentication::None, socket, target).await
     }
 
-    /// Initiates a BIND request to the specified proxy using given username
-    /// and password.
+    /// Initiates a BIND request to the specified proxy using given username,
+    /// password and socket to the proxy.
     ///
     /// The proxy will filter incoming connections based on the value of
     /// `target`.

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -159,7 +159,7 @@ where S: AsyncRead + AsyncWrite + Unpin
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn connect_with_password_with_socket<'a, 't, T>(
+    pub async fn connect_with_password_and_socket<'a, 't, T>(
         socket: S,
         target: T,
         username: &'a str,
@@ -594,7 +594,7 @@ where S: AsyncRead + AsyncWrite + Unpin
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn bind_with_password_with_socket<'a, 't, T>(
+    pub async fn bind_with_password_and_socket<'a, 't, T>(
         socket: S,
         target: T,
         username: &'a str,

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -70,8 +70,8 @@ impl Socks5Stream<TcpStream> {
         Self::execute_command(proxy, target, Authentication::None, Command::Connect).await
     }
 
-    /// Connects to a target server through a SOCKS5 proxy using given username
-    /// , password and the address of the proxy.
+    /// Connects to a target server through a SOCKS5 proxy using given username,
+    /// password and the address of the proxy.
     ///
     /// # Error
     ///
@@ -97,8 +97,8 @@ impl Socks5Stream<TcpStream> {
     }
 
     #[cfg(feature = "tor")]
-    /// Resolve the domain name to an ip using special Tor Resolve command, by connecting to a Tor
-    /// compatible proxy given it's address.
+    /// Resolve the domain name to an ip using special Tor Resolve command, by
+    /// connecting to a Tor compatible proxy given it's address.
     pub async fn tor_resolve<'t, P, T>(proxy: P, target: T) -> Result<TargetAddr<'static>>
     where
         P: ToProxyAddrs,
@@ -110,8 +110,9 @@ impl Socks5Stream<TcpStream> {
     }
 
     #[cfg(feature = "tor")]
-    /// Perform a reverse DNS query on the given ip using special Tor Resolve PTR command, by connecting to a Tor
-    /// compatible proxy given it's address.
+    /// Perform a reverse DNS query on the given ip using special Tor Resolve
+    /// PTR command, by connecting to a Tor compatible proxy given it's
+    /// address.
     pub async fn tor_resolve_ptr<'t, P, T>(proxy: P, target: T) -> Result<TargetAddr<'static>>
     where
         P: ToProxyAddrs,
@@ -198,10 +199,9 @@ where S: AsyncRead + AsyncWrite + Unpin
         Ok(())
     }
 
-
     #[cfg(feature = "tor")]
-    /// Resolve the domain name to an ip using special Tor Resolve command, by connecting to a Tor
-    /// compatible proxy given a socket to it.
+    /// Resolve the domain name to an ip using special Tor Resolve command, by
+    /// connecting to a Tor compatible proxy given a socket to it.
     pub async fn tor_resolve_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolve).await?;
@@ -210,8 +210,9 @@ where S: AsyncRead + AsyncWrite + Unpin
     }
 
     #[cfg(feature = "tor")]
-    /// Perform a reverse DNS query on the given ip using special Tor Resolve PTR command, by connecting to a Tor
-    /// compatible proxy given a socket to it.
+    /// Perform a reverse DNS query on the given ip using special Tor Resolve
+    /// PTR command, by connecting to a Tor compatible proxy given a socket
+    /// to it.
     pub async fn tor_resolve_ptr_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock =
@@ -578,7 +579,8 @@ impl Socks5Listener<TcpStream> {
 impl<S> Socks5Listener<S>
 where S: AsyncRead + AsyncWrite + Unpin
 {
-    /// Initiates a BIND request to the specified proxy using the given socket to it.
+    /// Initiates a BIND request to the specified proxy using the given socket
+    /// to it.
     ///
     /// The proxy will filter incoming connections based on the value of
     /// `target`.

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -196,7 +196,7 @@ where S: AsyncRead + AsyncWrite + Unpin
 
 
     #[cfg(feature = "tor")]
-    pub async fn tor_resolve_with_socket<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
+    pub async fn tor_resolve_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolve).await?;
 
@@ -204,7 +204,7 @@ where S: AsyncRead + AsyncWrite + Unpin
     }
 
     #[cfg(feature = "tor")]
-    pub async fn tor_resolve_ptr_with_socket<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
+    pub async fn tor_resolve_ptr_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where T: IntoTargetAddr<'t> {
         let sock =
             Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolvePtr).await?;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -74,11 +74,11 @@ impl<S> Socks5Stream<S>
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn connect_via<'t, T>(socket: S, target: T) -> Result<Socks5Stream<S>>
+    pub async fn connect_with_socket<'t, T>(socket: S, target: T) -> Result<Socks5Stream<S>>
     where
         T: IntoTargetAddr<'t>,
     {
-        Self::execute_command_via(socket, target, Authentication::None, Command::Connect).await
+        Self::execute_command_with_socket(socket, target, Authentication::None, Command::Connect).await
     }
 
     /// Connects to a target server through a SOCKS5 proxy using given username
@@ -114,7 +114,7 @@ impl<S> Socks5Stream<S>
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn connect_with_password_via<'a, 't, T>(
+    pub async fn connect_with_password_with_socket<'a, 't, T>(
         socket: S,
         target: T,
         username: &'a str,
@@ -123,7 +123,7 @@ impl<S> Socks5Stream<S>
     where
         T: IntoTargetAddr<'t>,
     {
-        Self::execute_command_via(
+        Self::execute_command_with_socket(
             socket,
             target,
             Authentication::Password { username, password },
@@ -161,11 +161,11 @@ impl<S> Socks5Stream<S>
     }
 
     #[cfg(feature = "tor")]
-    pub async fn tor_resolve_via<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
+    pub async fn tor_resolve_with_socket<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where
         T: IntoTargetAddr<'t>,
     {
-        let sock = Self::execute_command_via(socket, target, Authentication::None, Command::TorResolve).await?;
+        let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolve).await?;
 
         Ok(sock.target_addr().to_owned())
     }
@@ -182,11 +182,11 @@ impl<S> Socks5Stream<S>
     }
 
     #[cfg(feature = "tor")]
-    pub async fn tor_resolve_ptr_via<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
+    pub async fn tor_resolve_ptr_with_socket<'t, P, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
     where
         T: IntoTargetAddr<'t>,
     {
-        let sock = Self::execute_command_via(socket, target, Authentication::None, Command::TorResolvePtr).await?;
+        let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolvePtr).await?;
 
         Ok(sock.target_addr().to_owned())
     }
@@ -210,7 +210,7 @@ impl<S> Socks5Stream<S>
         Ok(sock)
     }
 
-    async fn execute_command_via<'a, 't, T>(
+    async fn execute_command_with_socket<'a, 't, T>(
         socket: S,
         target: T,
         auth: Authentication<'a>,
@@ -527,11 +527,11 @@ impl<S> Socks5Listener<S>
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn bind_via<'t, T>(socket: S, target: T) -> Result<Socks5Listener<S>>
+    pub async fn bind_with_socket<'t, T>(socket: S, target: T) -> Result<Socks5Listener<S>>
     where
         T: IntoTargetAddr<'t>,
     {
-        Self::bind_with_auth_via(Authentication::None, socket, target).await
+        Self::bind_with_auth_with_socket(Authentication::None, socket, target).await
     }
 
     /// Initiates a BIND request to the specified proxy using given username
@@ -567,7 +567,7 @@ impl<S> Socks5Listener<S>
     ///
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
-    pub async fn bind_with_password_via<'a, 't, T>(
+    pub async fn bind_with_password_with_socket<'a, 't, T>(
         socket: S,
         target: T,
         username: &'a str,
@@ -576,7 +576,7 @@ impl<S> Socks5Listener<S>
     where
         T: IntoTargetAddr<'t>,
     {
-        Self::bind_with_auth_via(Authentication::Password { username, password }, socket, target).await
+        Self::bind_with_auth_with_socket(Authentication::Password { username, password }, socket, target).await
     }
 
     async fn bind_with_auth<'t, P, T>(auth: Authentication<'_>, proxy: P, target: T) -> Result<Socks5Listener<TcpStream>>
@@ -596,7 +596,7 @@ impl<S> Socks5Listener<S>
         Ok(Socks5Listener { inner: socket })
     }
 
-    async fn bind_with_auth_via<'t, T>(auth: Authentication<'_>, socket: S, target: T) -> Result<Socks5Listener<S>>
+    async fn bind_with_auth_with_socket<'t, T>(auth: Authentication<'_>, socket: S, target: T) -> Result<Socks5Listener<S>>
     where
         T: IntoTargetAddr<'t>,
     {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -8,6 +8,7 @@ use std::{
 use tokio::{
     io::{copy, AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
+    net::TcpStream,
     runtime::Runtime,
 };
 use tokio_socks::{
@@ -37,20 +38,20 @@ pub async fn echo_server() -> Result<()> {
     Ok(())
 }
 
-pub async fn reply_response(mut socket: Socks5Stream) -> Result<[u8; 5]> {
+pub async fn reply_response(mut socket: Socks5Stream<TcpStream>) -> Result<[u8; 5]> {
     socket.write_all(MSG).await?;
     let mut buf = [0; 5];
     socket.read_exact(&mut buf).await?;
     Ok(buf)
 }
 
-pub async fn test_connect(socket: Socks5Stream) -> Result<()> {
+pub async fn test_connect(socket: Socks5Stream<TcpStream>) -> Result<()> {
     let res = reply_response(socket).await?;
     assert_eq!(&res[..], MSG);
     Ok(())
 }
 
-pub fn test_bind(listener: Socks5Listener) -> Result<()> {
+pub fn test_bind(listener: Socks5Listener<TcpStream>) -> Result<()> {
     let bind_addr = listener.bind_addr().to_owned();
     runtime().lock().unwrap().spawn(async move {
         let mut stream = listener.accept().await.unwrap();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Mutex,
 };
 use tokio::{
-    io::{copy, split, AsyncReadExt, AsyncWriteExt, AsyncRead, AsyncWrite},
+    io::{copy, split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, UnixStream},
     runtime::Runtime,
 };

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -20,7 +20,7 @@ socat UNIX-LISTEN:${SOCK},reuseaddr,fork TCP:${PROXY_HOST} &
 for test in ${list}; do
     3proxy ${dir}/${test}.cfg
     sleep 1
-    cargo test --test ${test}
+    cargo test --test ${test} -- --test-threads 1
     test_exit_code=$?
 
     pkill -F /tmp/3proxy-test.pid

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -2,6 +2,9 @@
 set -x
 
 dir="$(dirname "$(which "$0")")"
+SOCK="/tmp/proxy.s"
+PROXY_HOST="127.0.0.1:41080"
+
 
 #socat tcp-listen:10007,fork exec:cat &
 #echo $! > /tmp/socat-test.pid
@@ -11,6 +14,8 @@ if test -z "$@"; then
 else
     list="$@"
 fi
+
+socat UNIX-LISTEN:${SOCK},reuseaddr,fork TCP:${PROXY_HOST} &
 
 for test in ${list}; do
     3proxy ${dir}/${test}.cfg

--- a/tests/long_username_password_auth.rs
+++ b/tests/long_username_password_auth.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
+use common::{connect_unix, runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
 use tokio_socks::{
     tcp::{Socks5Listener, Socks5Stream},
     Result,
@@ -21,6 +21,31 @@ fn bind_long_username_password() -> Result<()> {
         let mut runtime = runtime().lock().unwrap();
         runtime.block_on(Socks5Listener::bind_with_password(
             PROXY_ADDR,
+            ECHO_SERVER_ADDR,
+            "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
+            "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"
+        ))
+    }?;
+    test_bind(bind)
+}
+
+#[test]
+fn connect_with_socket_long_username_password() -> Result<()> {
+    let mut runtime = runtime().lock().unwrap();
+    let socket = runtime.block_on(connect_unix())?;
+    let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
+        socket, ECHO_SERVER_ADDR, "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
+                                                                    "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"))?;
+    runtime.block_on(test_connect(conn))
+}
+
+#[test]
+fn bind_with_socket_long_username_password() -> Result<()> {
+    let bind = {
+        let mut runtime = runtime().lock().unwrap();
+        let socket = runtime.block_on(connect_unix())?;
+        runtime.block_on(Socks5Listener::bind_with_password_and_socket(
+            socket,
             ECHO_SERVER_ADDR,
             "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
             "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"

--- a/tests/no_auth.rs
+++ b/tests/no_auth.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use crate::common::{runtime, test_bind};
-use common::{test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
+use common::{connect_unix, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
 use tokio_socks::{
     tcp::{Socks5Listener, Socks5Stream},
     Result,
@@ -19,6 +19,24 @@ fn bind_no_auth() -> Result<()> {
     let bind = {
         let mut runtime = runtime().lock().unwrap();
         runtime.block_on(Socks5Listener::bind(PROXY_ADDR, ECHO_SERVER_ADDR))
+    }?;
+    test_bind(bind)
+}
+
+#[test]
+fn connect_with_socket_no_auth() -> Result<()> {
+    let mut runtime = runtime().lock().unwrap();
+    let socket = runtime.block_on(connect_unix())?;
+    let conn = runtime.block_on(Socks5Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
+    runtime.block_on(test_connect(conn))
+}
+
+#[test]
+fn bind_with_socket_no_auth() -> Result<()> {
+    let bind = {
+        let mut runtime = runtime().lock().unwrap();
+        let socket = runtime.block_on(connect_unix())?;
+        runtime.block_on(Socks5Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;
     test_bind(bind)
 }

--- a/tests/username_auth.rs
+++ b/tests/username_auth.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
+use common::{connect_unix, runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR};
 use tokio_socks::{
     tcp::{Socks5Listener, Socks5Stream},
     Result,
@@ -24,6 +24,34 @@ fn bind_username_auth() -> Result<()> {
         let mut runtime = runtime().lock().unwrap();
         runtime.block_on(Socks5Listener::bind_with_password(
             PROXY_ADDR,
+            ECHO_SERVER_ADDR,
+            "mylogin",
+            "mypassword",
+        ))
+    }?;
+    test_bind(bind)
+}
+
+#[test]
+fn connect_with_socket_username_auth() -> Result<()> {
+    let mut runtime = runtime().lock().unwrap();
+    let socket = runtime.block_on(connect_unix())?;
+    let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
+        socket,
+        ECHO_SERVER_ADDR,
+        "mylogin",
+        "mypassword",
+    ))?;
+    runtime.block_on(test_connect(conn))
+}
+
+#[test]
+fn bind_with_socket_username_auth() -> Result<()> {
+    let bind = {
+        let mut runtime = runtime().lock().unwrap();
+        let socket = runtime.block_on(connect_unix())?;
+        runtime.block_on(Socks5Listener::bind_with_password_and_socket(
+            socket,
             ECHO_SERVER_ADDR,
             "mylogin",
             "mypassword",


### PR DESCRIPTION
This is an attempt at solving both #5 and #19.
Most code is here, but it lacks documentation, tests, and an example.

This _does_ break compatibility as some types that were fixed are now parametrized, however I've mostly kept previous interface so that changes are actually minimal.