### PR TITLE
Reduce dependencies on `futures` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,13 @@ name = "tor"
 required-features = ["tor"]
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", features = ["io-util", "net"] }
 either = "1"
 thiserror = "1.0"
 
 [dev-dependencies]
+futures-executor = "0.3"
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread", "net"] }
 once_cell = "1.2.0"
 hyper = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 use either::Either;
-use futures::{
+use futures_util::{
     future,
     stream::{self, Once, Stream},
-    task::{Context, Poll},
 };
 use std::{
     borrow::Cow,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
     pin::Pin,
+    task::{Context, Poll},
     vec,
 };
 
@@ -264,7 +264,8 @@ pub mod tcp;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{executor::block_on, StreamExt};
+    use futures_executor::block_on;
+    use futures_util::StreamExt;
 
     fn to_proxy_addrs<T: ToProxyAddrs>(t: T) -> Result<Vec<SocketAddr>> {
         Ok(block_on(t.to_proxy_addrs().map(Result::unwrap).collect()))

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,17 +1,12 @@
 use crate::{Authentication, Error, IntoTargetAddr, Result, TargetAddr, ToProxyAddrs};
-use futures::{
-    stream,
-    stream::Fuse,
-    task::{Context, Poll},
-    Stream,
-    StreamExt,
-};
+use futures_util::stream::{self, Fuse, Stream, StreamExt};
 use std::{
     borrow::Borrow,
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::{Deref, DerefMut},
     pin::Pin,
+    task::{Context, Poll},
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf},


### PR DESCRIPTION
This will no longer pull `futures-executor` for dependent projects