### PR TITLE
Require `tor` feature for the `socket` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ travis-ci = { repository = "sticnarf/tokio-socks" }
 tor = []
 
 [[example]]
+name = "socket"
+required-features = ["tor"]
+
+[[example]]
 name = "tor"
 required-features = ["tor"]
 


### PR DESCRIPTION
The `tor` feature is required to build the `socket` example