### PR TITLE
Fix broken apt install on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,12 +21,15 @@ jobs:
           override: true
       - name: Install 3proxy
         run: |
-          sudo add-apt-repository ppa:artyom.h31/3proxy -y
+          cd $HOME
+          curl -OL https://github.com/3proxy/3proxy/archive/refs/tags/0.8.13.tar.gz
+          tar xvf 0.8.13.tar.gz
+          cd 3proxy-0.8.13 && ln -s Makefile.Linux Makefile && make -j$(nproc)
           sudo apt-get update
-          sudo apt-get install 3proxy socat -y
+          sudo apt-get install socat -y
       - name: Run tests
         run: |
           cargo build --examples
           cargo build --verbose --all
           cargo test --lib --verbose
-          tests/integration_tests.sh
+          env PATH=$HOME/3proxy-0.8.13/src:$PATH tests/integration_tests.sh


### PR DESCRIPTION
Compile 3proxy 0.8 instead of using the broken ppa.