### PR TITLE
Draft: Support for GSSApi Authentication for SOCKS5

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,9 @@ pub enum Error {
 
     #[error("Request rejected because the client program and identd report different user-ids")]
     InvalidUserIdAuthFailure,
+ 
+    #[error("Gssapi auth failure, code: {0}")]
+    GssapiAuthFailure(u8),
 }
 
 ///// Result type of `tokio-socks`


### PR DESCRIPTION
RFC Followed: [GSSAPI Support RFC LINK](https://www.rfc-editor.org/rfc/rfc1961.html)

Code is written per RFC basis and has been reviewed internally,. 
Any Ideas For testing this are welcome.