### PR TITLE
Add tests and more traits and impls and etc.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
+          components: clippy
           override: true
+      - name: Clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Install 3proxy
         run: |
           cd $HOME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,11 @@ jobs:
           cd 3proxy-0.8.13 && ln -s Makefile.Linux Makefile && make -j$(nproc)
           sudo apt-get update
           sudo apt-get install socat -y
+      - name: Build
+        run: |
+          cargo build --examples --all-features
+          cargo build --verbose --all --all-features
+          cargo test --lib --verbose --all-features
       - name: Run tests
         run: |
-          cargo build --examples
-          cargo build --verbose --all
-          cargo test --lib --verbose
           env PATH=$HOME/3proxy-0.8.13/src:$PATH tests/integration_tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ jobs:
           override: true
       - name: Clippy
         run: |
+          cargo clippy --all-targets --no-default-features --features=tokio -- -D warnings
+          cargo clippy --all-targets --no-default-features --features=tokio,tor -- -D warnings
+          cargo clippy --all-targets --no-default-features --features=futures-io -- -D warnings
+          cargo clippy --all-targets --no-default-features --features=futures-io,tor -- -D warnings
           cargo clippy --all-targets --all-features -- -D warnings
       - name: Install 3proxy
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 travis-ci = { repository = "sticnarf/tokio-socks" }
 
 [features]
-default = ["tokio", "futures-io"]
+default = ["tokio"]
 tor = []
 futures-io = ["dep:futures-io"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread", "net"] }
 once_cell = "1.2.0"
 hyper = "0.14"
+async-std = "1.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 travis-ci = { repository = "sticnarf/tokio-socks" }
 
 [features]
-default = ["tokio"]
+default = ["tokio", "futures-io"]
 tor = []
 futures-io = ["dep:futures-io"]
 
@@ -41,6 +41,8 @@ thiserror = "1.0"
 
 [dev-dependencies]
 futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["io"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread", "net"] }
 once_cell = "1.2.0"
 hyper = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ thiserror = "1.0"
 [dev-dependencies]
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
-tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread", "net"] }
 once_cell = "1.2.0"
 hyper = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,16 @@ tor = []
 futures-io = ["dep:futures-io"]
 
 [[example]]
+name = "chainproxy"
+required-features = ["tokio"]
+
+[[example]]
 name = "socket"
-required-features = ["tor"]
+required-features = ["tokio", "tor"]
 
 [[example]]
 name = "tor"
-required-features = ["tor"]
+required-features = ["tokio", "tor"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Asynchronous SOCKS proxy support for Rust.
 - [X] Chain proxies ([see example](examples/chainproxy.rs))
 - [X] SOCKS4
 
+## Compatibility with Other Async Runtimes
+
+By default use `tokio` feature, as the crate name suggests.
+
+Compatibility with `futures-io` can be enabled by enabling the `futures-io` feature
+and `use tokio_socks::io::FuturesIoCompatExt`.
+
+When using `default-features = false` with `futures-io`, tokio is not pulled in as a dependency.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](/LICENSE) file for details.

--- a/examples/socket.rs
+++ b/examples/socket.rs
@@ -39,6 +39,6 @@ async fn connect() -> Result<(), Error> {
 }
 
 fn main() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     rt.block_on(connect()).unwrap();
 }

--- a/examples/tor.rs
+++ b/examples/tor.rs
@@ -29,6 +29,6 @@ async fn connect() -> Result<(), Error> {
 }
 
 fn main() {
-    let mut rt = Runtime::new().unwrap();
+    let rt = Runtime::new().unwrap();
     rt.block_on(connect()).unwrap();
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,7 @@
 use_small_heuristics = "Default"
 hard_tabs = false
 imports_layout = "HorizontalVertical"
-merge_imports = true
+imports_granularity = "Crate"
 match_block_trailing_comma = true
 max_width = 120
 newline_style = "Unix"
@@ -9,8 +9,6 @@ normalize_comments = true
 reorder_imports = true
 reorder_modules = true
 reorder_impl_items = true
-report_todo = "Never"
-report_fixme = "Never"
 space_after_colon = true
 space_before_colon = false
 struct_lit_single_line = true

--- a/src/io/futures.rs
+++ b/src/io/futures.rs
@@ -2,18 +2,43 @@ use super::{AsyncSocket, Compat};
 use futures_io::{AsyncRead, AsyncWrite};
 use std::{
     io::Result as IoResult,
+    ops::DerefMut,
     pin::Pin,
     task::{Context, Poll},
 };
 
 impl<S> AsyncSocket for Compat<S>
-where S: AsyncRead + AsyncWrite
+where S: AsyncRead + AsyncWrite + Unpin
 {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<IoResult<usize>> {
-        unsafe { AsyncRead::poll_read(self.map_unchecked_mut(|s| &mut s.0), cx, buf) }
+        AsyncRead::poll_read(Pin::new(self.get_mut().deref_mut()), cx, buf)
     }
 
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<IoResult<usize>> {
-        unsafe { AsyncWrite::poll_write(self.map_unchecked_mut(|s| &mut s.0), cx, buf) }
+        AsyncWrite::poll_write(Pin::new(self.get_mut().deref_mut()), cx, buf)
+    }
+}
+
+impl<S> AsyncRead for Compat<S>
+where S: AsyncRead + Unpin
+{
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<IoResult<usize>> {
+        AsyncRead::poll_read(Pin::new(self.get_mut().deref_mut()), cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for Compat<S>
+where S: AsyncWrite + Unpin
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<IoResult<usize>> {
+        AsyncWrite::poll_write(Pin::new(self.get_mut().deref_mut()), cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
+        AsyncWrite::poll_flush(Pin::new(self.get_mut().deref_mut()), cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
+        AsyncWrite::poll_close(Pin::new(self.get_mut().deref_mut()), cx)
     }
 }

--- a/src/io/futures.rs
+++ b/src/io/futures.rs
@@ -14,7 +14,7 @@ use std::{
 
 /// A compatibility layer for using `futures-io` types with `async-socks5`.
 ///
-/// Use `FuturesIoCompatExt` to convert `futures-io` types to `Compat` types.
+/// See `FuturesIoCompatExt` trait for details.
 pub struct Compat<S>(S);
 
 impl<S> Compat<S> {
@@ -49,10 +49,10 @@ impl<S> DerefMut for Compat<S> {
 /// use async_std::os::unix::net::UnixStream;
 /// use tokio_socks::{io::FuturesIoCompatExt as _, tcp::Socks5Stream};
 ///
-/// let socket = UnixStream::connect(proxy_addr) // Compat<UnixStream>
+/// let socket = UnixStream::connect(proxy_addr)
 ///     .await
 ///     .map_err(Error::Io)?
-///     .compat();
+///     .compat(); // Compat<UnixStream>
 /// let conn =
 ///     Socks5Stream::connect_with_password_and_socket(socket, target, username, pswd).await?;
 /// // Socks5Stream has implemented futures-io AsyncRead + AsyncWrite.

--- a/src/io/futures.rs
+++ b/src/io/futures.rs
@@ -1,16 +1,13 @@
+use super::{AsyncSocket, Compat};
+use futures_io::{AsyncRead, AsyncWrite};
 use std::{
     io::Result as IoResult,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use futures_io::{AsyncRead, AsyncWrite};
-
-use super::{AsyncSocket, Compat};
-
 impl<S> AsyncSocket for Compat<S>
-where
-    S: AsyncRead + AsyncWrite,
+where S: AsyncRead + AsyncWrite
 {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<IoResult<usize>> {
         unsafe { AsyncRead::poll_read(self.map_unchecked_mut(|s| &mut s.0), cx, buf) }

--- a/src/io/futures.rs
+++ b/src/io/futures.rs
@@ -1,11 +1,50 @@
-use super::{AsyncSocket, Compat};
+use super::AsyncSocket;
 use futures_io::{AsyncRead, AsyncWrite};
 use std::{
     io::Result as IoResult,
-    ops::DerefMut,
+    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
 };
+
+pub struct Compat<S>(S);
+
+impl<S> Compat<S> {
+    pub fn new(inner: S) -> Self {
+        Compat(inner)
+    }
+
+    pub fn into_inner(self) -> S {
+        self.0
+    }
+}
+
+impl<S> Deref for Compat<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S> DerefMut for Compat<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub trait FuturesIoCompatExt {
+    fn compat(self) -> Compat<Self>
+    where Self: Sized;
+}
+
+impl<S> FuturesIoCompatExt for S
+where S: AsyncRead + AsyncWrite + Unpin
+{
+    fn compat(self) -> Compat<Self> {
+        Compat::new(self)
+    }
+}
 
 impl<S> AsyncSocket for Compat<S>
 where S: AsyncRead + AsyncWrite + Unpin

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -21,7 +21,7 @@ pub use futures::{Compat, FuturesIoCompatExt};
 /// Any type that implements tokio's `AsyncRead` and `AsyncWrite` traits
 /// has implemented `AsyncSocket` trait.
 ///
-/// Use `FuturesIoCompatExt` to wrap `futures-io` types.
+/// Use `FuturesIoCompatExt` to wrap `futures-io` types as `AsyncSocket` types.
 pub trait AsyncSocket {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, Error>>;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -8,36 +8,12 @@ use std::{
     future::Future,
     io::{Error, ErrorKind},
     mem,
-    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
 };
 
-pub struct Compat<S>(S);
-
-impl<S> Compat<S> {
-    pub fn new(inner: S) -> Self {
-        Compat(inner)
-    }
-
-    pub fn into_inner(self) -> S {
-        self.0
-    }
-}
-
-impl<S> Deref for Compat<S> {
-    type Target = S;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<S> DerefMut for Compat<S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+#[cfg(feature = "futures-io")]
+pub use futures::{Compat, FuturesIoCompatExt};
 
 pub trait AsyncSocket {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, Error>>;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,3 +1,4 @@
+//! Asynchronous I/O abstractions for sockets.
 #[cfg(feature = "futures-io")]
 mod futures;
 #[cfg(feature = "tokio")]
@@ -15,6 +16,12 @@ use std::{
 #[cfg(feature = "futures-io")]
 pub use futures::{Compat, FuturesIoCompatExt};
 
+/// A trait for asynchronous socket I/O.
+///
+/// Any type that implements tokio's `AsyncRead` and `AsyncWrite` traits
+/// has implemented `AsyncSocket` trait.
+///
+/// Use `FuturesIoCompatExt` to wrap `futures-io` types.
 pub trait AsyncSocket {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, Error>>;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -8,6 +8,7 @@ use std::{
     future::Future,
     io::{Error, ErrorKind},
     mem,
+    ops::{Deref, DerefMut},
     pin::Pin,
     task::{Context, Poll},
 };
@@ -17,6 +18,24 @@ pub struct Compat<S>(S);
 impl<S> Compat<S> {
     pub fn new(inner: S) -> Self {
         Compat(inner)
+    }
+
+    pub fn into_inner(self) -> S {
+        self.0
+    }
+}
+
+impl<S> Deref for Compat<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S> DerefMut for Compat<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/src/io/tokio.rs
+++ b/src/io/tokio.rs
@@ -1,3 +1,5 @@
+//! AsyncSocket trait implementation for tokio's AsyncRead + AsyncWrite
+//! traits.
 use super::AsyncSocket;
 use futures_util::ready;
 use std::{

--- a/src/io/tokio.rs
+++ b/src/io/tokio.rs
@@ -1,17 +1,14 @@
+use super::AsyncSocket;
+use futures_util::ready;
 use std::{
     io::Result as IoResult,
     pin::Pin,
     task::{Context, Poll},
 };
-
-use futures_util::ready;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use super::AsyncSocket;
-
 impl<S> AsyncSocket for S
-where
-    S: AsyncRead + AsyncWrite,
+where S: AsyncRead + AsyncWrite
 {
     fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<IoResult<usize>> {
         let mut buf = ReadBuf::new(buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,8 @@ impl<'a> ToProxyAddrs for &'a [SocketAddr] {
     type Output = ProxyAddrsStream;
 
     fn to_proxy_addrs(&self) -> Self::Output {
-        ProxyAddrsStream(Some(IoResult::Ok(self.to_vec().into_iter())))
+        let addrs = self.to_vec();
+        ProxyAddrsStream(Some(IoResult::Ok(addrs.into_iter())))
     }
 }
 
@@ -235,8 +236,7 @@ impl IntoTargetAddr<'static> for (String, u16) {
 }
 
 impl<'a, T> IntoTargetAddr<'a> for &'a T
-where
-    T: IntoTargetAddr<'a> + Copy,
+where T: IntoTargetAddr<'a> + Copy
 {
     fn into_target_addr(self) -> Result<TargetAddr<'a>> {
         (*self).into_target_addr()
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn converts_socket_addr_ref_to_proxy_addrs() -> Result<()> {
         let addr = SocketAddr::from(([1, 1, 1, 1], 443));
-        let res = to_proxy_addrs(&addr)?;
+        let res = to_proxy_addrs(addr)?;
         assert_eq!(&res[..], &[addr]);
         Ok(())
     }
@@ -301,9 +301,7 @@ mod tests {
     }
 
     fn into_target_addr<'a, T>(t: T) -> Result<TargetAddr<'a>>
-    where
-        T: IntoTargetAddr<'a>,
-    {
+    where T: IntoTargetAddr<'a> {
         t.into_target_addr()
     }
 
@@ -318,7 +316,7 @@ mod tests {
     #[test]
     fn converts_socket_addr_ref_to_target_addr() -> Result<()> {
         let addr = SocketAddr::from(([1, 1, 1, 1], 443));
-        let res = into_target_addr(&addr)?;
+        let res = into_target_addr(addr)?;
         assert_eq!(TargetAddr::Ip(addr), res);
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ use std::{
 
 pub use error::Error;
 
+#[cfg(not(any(feature = "tokio", feature = "futures-io")))]
+compile_error!("At least one of the features `tokio` or `futures-io` must be enabled.");
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A trait for objects which can be converted or resolved to one or more

--- a/src/tcp/socks4.rs
+++ b/src/tcp/socks4.rs
@@ -4,9 +4,9 @@ use crate::{
     IntoTargetAddr,
     Result,
     TargetAddr,
-    ToProxyAddrs,
 };
 
+use futures_util::stream::{self, Fuse, Stream, StreamExt};
 use std::{
     borrow::Borrow,
     io,
@@ -16,7 +16,8 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::stream::{self, Fuse, Stream, StreamExt};
+#[cfg(feature = "tokio")]
+use crate::ToProxyAddrs;
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
 
@@ -195,6 +196,7 @@ where S: AsyncSocket + Unpin
 pub struct Socks4Connector<'a, 't, S> {
     user_id: Option<&'a str>,
     command: CommandV4,
+    #[allow(dead_code)]
     proxy: Fuse<S>,
     target: TargetAddr<'t>,
     buf: [u8; 513],

--- a/src/tcp/socks5.rs
+++ b/src/tcp/socks5.rs
@@ -5,7 +5,6 @@ use crate::{
     IntoTargetAddr,
     Result,
     TargetAddr,
-    ToProxyAddrs,
 };
 
 use std::{
@@ -18,6 +17,9 @@ use std::{
 };
 
 use futures_util::stream::{self, Fuse, Stream, StreamExt};
+
+#[cfg(feature = "tokio")]
+use crate::ToProxyAddrs;
 #[cfg(feature = "tokio")]
 use tokio::net::TcpStream;
 
@@ -264,6 +266,7 @@ where S: AsyncSocket + Unpin
 pub struct SocksConnector<'a, 't, S> {
     auth: Authentication<'a>,
     command: Command,
+    #[allow(dead_code)]
     proxy: Fuse<S>,
     target: TargetAddr<'t>,
     buf: [u8; 513],

--- a/src/tcp/socks5.rs
+++ b/src/tcp/socks5.rs
@@ -1,6 +1,11 @@
 use crate::{
     io::{AsyncSocket, AsyncSocketExt},
-    Authentication, Error, IntoTargetAddr, Result, TargetAddr, ToProxyAddrs,
+    Authentication,
+    Error,
+    IntoTargetAddr,
+    Result,
+    TargetAddr,
+    ToProxyAddrs,
 };
 
 use std::{
@@ -143,8 +148,7 @@ impl Socks5Stream<TcpStream> {
 }
 
 impl<S> Socks5Stream<S>
-where
-    S: AsyncSocket + Unpin,
+where S: AsyncSocket + Unpin
 {
     /// Connects to a target server through a SOCKS5 proxy given a socket to it.
     ///
@@ -153,9 +157,7 @@ where
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
     pub async fn connect_with_socket<'t, T>(socket: S, target: T) -> Result<Socks5Stream<S>>
-    where
-        T: IntoTargetAddr<'t>,
-    {
+    where T: IntoTargetAddr<'t> {
         Self::execute_command_with_socket(socket, target, Authentication::None, Command::Connect).await
     }
 
@@ -184,15 +186,15 @@ where
         .await
     }
 
-    fn validate_auth<'a>(auth: &Authentication<'a>) -> Result<()> {
+    fn validate_auth(auth: &Authentication<'_>) -> Result<()> {
         match auth {
             Authentication::Password { username, password } => {
                 let username_len = username.as_bytes().len();
-                if username_len < 1 || username_len > 255 {
+                if !(1..=255).contains(&username_len) {
                     Err(Error::InvalidAuthValues("username length should between 1 to 255"))?
                 }
                 let password_len = password.as_bytes().len();
-                if password_len < 1 || password_len > 255 {
+                if !(1..=255).contains(&password_len) {
                     Err(Error::InvalidAuthValues("password length should between 1 to 255"))?
                 }
             },
@@ -205,9 +207,7 @@ where
     /// Resolve the domain name to an ip using special Tor Resolve command, by
     /// connecting to a Tor compatible proxy given a socket to it.
     pub async fn tor_resolve_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
-    where
-        T: IntoTargetAddr<'t>,
-    {
+    where T: IntoTargetAddr<'t> {
         let sock = Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolve).await?;
 
         Ok(sock.target_addr().to_owned())
@@ -218,9 +218,7 @@ where
     /// PTR command, by connecting to a Tor compatible proxy given a socket
     /// to it.
     pub async fn tor_resolve_ptr_with_socket<'t, T>(socket: S, target: T) -> Result<TargetAddr<'static>>
-    where
-        T: IntoTargetAddr<'t>,
-    {
+    where T: IntoTargetAddr<'t> {
         let sock =
             Self::execute_command_with_socket(socket, target, Authentication::None, Command::TorResolvePtr).await?;
 
@@ -274,8 +272,7 @@ pub struct SocksConnector<'a, 't, S> {
 }
 
 impl<'a, 't, S> SocksConnector<'a, 't, S>
-where
-    S: Stream<Item = Result<SocketAddr>> + Unpin,
+where S: Stream<Item = Result<SocketAddr>> + Unpin
 {
     fn new(auth: Authentication<'a>, command: Command, proxy: Fuse<S>, target: TargetAddr<'t>) -> Self {
         SocksConnector {
@@ -498,7 +495,7 @@ where
             },
             // Domain
             0x03 => {
-                let domain_bytes = (&self.buf[5..(self.len - 2)]).to_vec();
+                let domain_bytes = self.buf[5..(self.len - 2)].to_vec();
                 let domain = String::from_utf8(domain_bytes)
                     .map_err(|_| Error::InvalidTargetAddress("not a valid UTF-8 string"))?;
                 let port = u16::from_be_bytes([self.buf[self.len - 2], self.buf[self.len - 1]]);
@@ -586,8 +583,7 @@ impl Socks5Listener<TcpStream> {
 }
 
 impl<S> Socks5Listener<S>
-where
-    S: AsyncSocket + Unpin,
+where S: AsyncSocket + Unpin
 {
     /// Initiates a BIND request to the specified proxy using the given socket
     /// to it.
@@ -600,9 +596,7 @@ where
     /// It propagates the error that occurs in the conversion from `T` to
     /// `TargetAddr`.
     pub async fn bind_with_socket<'t, T>(socket: S, target: T) -> Result<Socks5Listener<S>>
-    where
-        T: IntoTargetAddr<'t>,
-    {
+    where T: IntoTargetAddr<'t> {
         Self::bind_with_auth_and_socket(Authentication::None, socket, target).await
     }
 
@@ -678,8 +672,7 @@ where
 
 #[cfg(feature = "tokio")]
 impl<T> tokio::io::AsyncRead for Socks5Stream<T>
-where
-    T: tokio::io::AsyncRead + Unpin,
+where T: tokio::io::AsyncRead + Unpin
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -692,8 +685,7 @@ where
 
 #[cfg(feature = "tokio")]
 impl<T> tokio::io::AsyncWrite for Socks5Stream<T>
-where
-    T: tokio::io::AsyncWrite + Unpin,
+where T: tokio::io::AsyncWrite + Unpin
 {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         tokio::io::AsyncWrite::poll_write(Pin::new(&mut self.socket), cx, buf)
@@ -710,8 +702,7 @@ where
 
 #[cfg(feature = "futures-io")]
 impl<T> futures_io::AsyncRead for Socks5Stream<T>
-where
-    T: futures_io::AsyncRead + Unpin,
+where T: futures_io::AsyncRead + Unpin
 {
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
         futures_io::AsyncRead::poll_read(Pin::new(&mut self.socket), cx, buf)
@@ -719,10 +710,8 @@ where
 }
 
 #[cfg(feature = "futures-io")]
-
 impl<T> futures_io::AsyncWrite for Socks5Stream<T>
-where
-    T: futures_io::AsyncWrite + Unpin,
+where T: futures_io::AsyncWrite + Unpin
 {
     fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         futures_io::AsyncWrite::poll_write(Pin::new(&mut self.socket), cx, buf)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use once_cell::sync::OnceCell;
 use std::{
     io::{Read, Write},
@@ -9,13 +10,17 @@ use tokio::{
     net::{TcpListener, UnixStream},
     runtime::Runtime,
 };
-use tokio_socks::{tcp::socks4::Socks4Listener, tcp::socks5::Socks5Listener, Error, Result};
+use tokio_socks::{
+    tcp::{socks4::Socks4Listener, socks5::Socks5Listener},
+    Error,
+    Result,
+};
 
-pub const UNIX_PROXY_ADDR: &'static str = "/tmp/proxy.s";
-pub const PROXY_ADDR: &'static str = "127.0.0.1:41080";
-pub const UNIX_SOCKS4_PROXY_ADDR: &'static str = "/tmp/socks4_proxy.s";
-pub const SOCKS4_PROXY_ADDR: &'static str = "127.0.0.1:41081";
-pub const ECHO_SERVER_ADDR: &'static str = "localhost:10007";
+pub const UNIX_PROXY_ADDR: &str = "/tmp/proxy.s";
+pub const PROXY_ADDR: &str = "127.0.0.1:41080";
+pub const UNIX_SOCKS4_PROXY_ADDR: &str = "/tmp/socks4_proxy.s";
+pub const SOCKS4_PROXY_ADDR: &str = "127.0.0.1:41081";
+pub const ECHO_SERVER_ADDR: &str = "localhost:10007";
 pub const MSG: &[u8] = b"hello";
 
 pub async fn echo_server() -> Result<()> {

--- a/tests/common/futures_utils.rs
+++ b/tests/common/futures_utils.rs
@@ -1,35 +1,25 @@
-#![allow(dead_code)]
-use once_cell::sync::OnceCell;
+use super::{tokio_utils::runtime, *};
+use futures_util::{io::copy, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use std::{
     io::{Read, Write},
     net::{SocketAddr, TcpStream as StdTcpStream},
-    sync::Mutex,
 };
-use tokio::{
-    io::{copy, split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    net::{TcpListener, UnixStream},
-    runtime::Runtime,
-};
+use tokio::net::{TcpListener, UnixStream};
 use tokio_socks::{
+    io::Compat,
     tcp::{socks4::Socks4Listener, socks5::Socks5Listener},
     Error,
     Result,
 };
-
-pub const UNIX_PROXY_ADDR: &str = "/tmp/proxy.s";
-pub const PROXY_ADDR: &str = "127.0.0.1:41080";
-pub const UNIX_SOCKS4_PROXY_ADDR: &str = "/tmp/socks4_proxy.s";
-pub const SOCKS4_PROXY_ADDR: &str = "127.0.0.1:41081";
-pub const ECHO_SERVER_ADDR: &str = "localhost:10007";
-pub const MSG: &[u8] = b"hello";
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 pub async fn echo_server() -> Result<()> {
     let listener = TcpListener::bind(&SocketAddr::from(([0, 0, 0, 0], 10007))).await?;
     loop {
         let (mut stream, _) = listener.accept().await?;
         tokio::spawn(async move {
-            let (mut reader, mut writer) = stream.split();
-            copy(&mut reader, &mut writer).await.unwrap();
+            let (reader, writer) = stream.split();
+            copy(&mut reader.compat(), &mut writer.compat_write()).await.unwrap();
         });
     }
 }
@@ -47,11 +37,13 @@ pub async fn test_connect<S: AsyncRead + AsyncWrite + Unpin>(socket: S) -> Resul
     Ok(())
 }
 
-pub fn test_bind<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(listener: Socks5Listener<S>) -> Result<()> {
+pub fn test_bind<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(
+    listener: Socks5Listener<Compat<S>>,
+) -> Result<()> {
     let bind_addr = listener.bind_addr().to_owned();
     runtime().lock().unwrap().spawn(async move {
         let stream = listener.accept().await.unwrap();
-        let (mut reader, mut writer) = split(stream);
+        let (mut reader, mut writer) = stream.split();
         copy(&mut reader, &mut writer).await.unwrap();
     });
 
@@ -63,24 +55,20 @@ pub fn test_bind<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(listener: S
     Ok(())
 }
 
-pub async fn connect_unix(proxy_addr: &'static str) -> Result<UnixStream> {
-    UnixStream::connect(proxy_addr).await.map_err(Error::Io)
+pub async fn connect_unix(proxy_addr: &str) -> Result<tokio_util::compat::Compat<UnixStream>> {
+    UnixStream::connect(proxy_addr)
+        .await
+        .map_err(Error::Io)
+        .map(|stream| stream.compat())
 }
 
-pub fn runtime() -> &'static Mutex<Runtime> {
-    static RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
-    RUNTIME.get_or_init(|| {
-        let runtime = Runtime::new().expect("Unable to create runtime");
-        runtime.spawn(async { echo_server().await.expect("Unable to bind") });
-        Mutex::new(runtime)
-    })
-}
-
-pub fn test_bind_socks4<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(listener: Socks4Listener<S>) -> Result<()> {
+pub fn test_bind_socks4<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(
+    listener: Socks4Listener<Compat<S>>,
+) -> Result<()> {
     let bind_addr = listener.bind_addr().to_owned();
     runtime().lock().unwrap().spawn(async move {
         let stream = listener.accept().await.unwrap();
-        let (mut reader, mut writer) = split(stream);
+        let (mut reader, mut writer) = AsyncReadExt::split(stream);
         copy(&mut reader, &mut writer).await.unwrap();
     });
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+pub mod futures_utils;
+#[cfg(feature = "tokio")]
+pub mod tokio_utils;
+
+#[cfg(feature = "tokio")]
+pub use tokio_utils::*;
+
+pub const UNIX_PROXY_ADDR: &str = "/tmp/proxy.s";
+pub const PROXY_ADDR: &str = "127.0.0.1:41080";
+pub const UNIX_SOCKS4_PROXY_ADDR: &str = "/tmp/socks4_proxy.s";
+pub const SOCKS4_PROXY_ADDR: &str = "127.0.0.1:41081";
+pub const ECHO_SERVER_ADDR: &str = "localhost:10007";
+pub const MSG: &[u8] = b"hello";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,6 +4,8 @@ pub mod futures_utils;
 #[cfg(feature = "tokio")]
 pub mod tokio_utils;
 
+#[cfg(feature = "futures-io")]
+pub use tokio_socks::io::FuturesIoCompatExt as _;
 #[cfg(feature = "tokio")]
 pub use tokio_utils::*;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 pub mod futures_utils;
 #[cfg(feature = "tokio")]

--- a/tests/common/tokio_utils.rs
+++ b/tests/common/tokio_utils.rs
@@ -1,0 +1,86 @@
+use super::*;
+use once_cell::sync::OnceCell;
+use std::{
+    io::{Read, Write},
+    net::{SocketAddr, TcpStream as StdTcpStream},
+    sync::Mutex,
+};
+use tokio::{
+    io::{copy, split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::{TcpListener, UnixStream},
+    runtime::Runtime,
+};
+use tokio_socks::{
+    tcp::{socks4::Socks4Listener, socks5::Socks5Listener},
+    Error,
+    Result,
+};
+
+pub async fn echo_server() -> Result<()> {
+    let listener = TcpListener::bind(&SocketAddr::from(([0, 0, 0, 0], 10007))).await?;
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+        tokio::spawn(async move {
+            let (mut reader, mut writer) = stream.split();
+            copy(&mut reader, &mut writer).await.unwrap();
+        });
+    }
+}
+
+pub async fn reply_response<S: AsyncRead + AsyncWrite + Unpin>(mut socket: S) -> Result<[u8; 5]> {
+    socket.write_all(MSG).await?;
+    let mut buf = [0; 5];
+    socket.read_exact(&mut buf).await?;
+    Ok(buf)
+}
+
+pub async fn test_connect<S: AsyncRead + AsyncWrite + Unpin>(socket: S) -> Result<()> {
+    let res = reply_response(socket).await?;
+    assert_eq!(&res[..], MSG);
+    Ok(())
+}
+
+pub fn test_bind<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(listener: Socks5Listener<S>) -> Result<()> {
+    let bind_addr = listener.bind_addr().to_owned();
+    runtime().lock().unwrap().spawn(async move {
+        let stream = listener.accept().await.unwrap();
+        let (mut reader, mut writer) = split(stream);
+        copy(&mut reader, &mut writer).await.unwrap();
+    });
+
+    let mut tcp = StdTcpStream::connect(bind_addr)?;
+    tcp.write_all(MSG)?;
+    let mut buf = [0; 5];
+    tcp.read_exact(&mut buf[..])?;
+    assert_eq!(&buf[..], MSG);
+    Ok(())
+}
+
+pub async fn connect_unix(proxy_addr: &str) -> Result<UnixStream> {
+    UnixStream::connect(proxy_addr).await.map_err(Error::Io)
+}
+
+pub fn runtime() -> &'static Mutex<Runtime> {
+    static RUNTIME: OnceCell<Mutex<Runtime>> = OnceCell::new();
+    RUNTIME.get_or_init(|| {
+        let runtime = Runtime::new().expect("Unable to create runtime");
+        runtime.spawn(async { echo_server().await.expect("Unable to bind") });
+        Mutex::new(runtime)
+    })
+}
+
+pub fn test_bind_socks4<S: 'static + AsyncRead + AsyncWrite + Unpin + Send>(listener: Socks4Listener<S>) -> Result<()> {
+    let bind_addr = listener.bind_addr().to_owned();
+    runtime().lock().unwrap().spawn(async move {
+        let stream = listener.accept().await.unwrap();
+        let (mut reader, mut writer) = split(stream);
+        copy(&mut reader, &mut writer).await.unwrap();
+    });
+
+    let mut tcp = StdTcpStream::connect(bind_addr)?;
+    tcp.write_all(MSG)?;
+    let mut buf = [0; 5];
+    tcp.read_exact(&mut buf[..])?;
+    assert_eq!(&buf[..], MSG);
+    Ok(())
+}

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -24,7 +24,7 @@ sleep 2
 for test in ${list}; do
     3proxy ${dir}/${test}.cfg
     sleep 1
-    cargo test --test ${test} -- --test-threads 1
+    cargo test --test ${test} --all-features -- --test-threads 1
     test_exit_code=$?
 
     pkill -F /tmp/3proxy-test.pid

--- a/tests/long_username_password_auth.rs
+++ b/tests/long_username_password_auth.rs
@@ -1,11 +1,13 @@
 mod common;
 
-use common::{connect_unix, runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR, UNIX_PROXY_ADDR};
+use common::*;
 use tokio_socks::{
+    io::Compat,
     tcp::socks5::{Socks5Listener, Socks5Stream},
     Result,
 };
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_long_username_password() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -15,6 +17,7 @@ fn connect_long_username_password() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_long_username_password() -> Result<()> {
     let bind = {
@@ -29,6 +32,7 @@ fn bind_long_username_password() -> Result<()> {
     test_bind(bind)
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_with_socket_long_username_password() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -39,6 +43,7 @@ fn connect_with_socket_long_username_password() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_with_socket_long_username_password() -> Result<()> {
     let bind = {
@@ -52,4 +57,33 @@ fn bind_with_socket_long_username_password() -> Result<()> {
         ))
     }?;
     test_bind(bind)
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
+    let runtime = runtime().lock().unwrap();
+    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+    let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
+        socket, ECHO_SERVER_ADDR, "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
+                                                                    "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"))?;
+    runtime.block_on(futures_utils::test_connect(conn))
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn bind_with_socket_long_username_password_futures_io() -> Result<()> {
+    let bind = {
+        let runtime = runtime().lock().unwrap();
+        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+        runtime.block_on(Socks5Listener::bind_with_password_and_socket(
+            socket,
+            ECHO_SERVER_ADDR,
+            "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
+            "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"
+        ))
+    }?;
+    futures_utils::test_bind(bind)
 }

--- a/tests/long_username_password_auth.rs
+++ b/tests/long_username_password_auth.rs
@@ -63,7 +63,7 @@ fn bind_with_socket_long_username_password() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
-    let runtime = runtime().lock().unwrap();
+    let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
         socket, ECHO_SERVER_ADDR, "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
@@ -76,7 +76,7 @@ fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
 #[test]
 fn bind_with_socket_long_username_password_futures_io() -> Result<()> {
     let bind = {
-        let runtime = runtime().lock().unwrap();
+        let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
         runtime.block_on(Socks5Listener::bind_with_password_and_socket(
             socket,

--- a/tests/long_username_password_auth.rs
+++ b/tests/long_username_password_auth.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use tokio_socks::{
-    io::Compat,
     tcp::socks5::{Socks5Listener, Socks5Stream},
     Result,
 };
@@ -59,10 +58,10 @@ fn bind_with_socket_long_username_password() -> Result<()> {
     test_bind(bind)
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
@@ -71,10 +70,10 @@ fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
     runtime.block_on(futures_utils::test_connect(conn))
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_long_username_password_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);

--- a/tests/long_username_password_auth.rs
+++ b/tests/long_username_password_auth.rs
@@ -61,9 +61,8 @@ fn bind_with_socket_long_username_password() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
-    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+    let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
         socket, ECHO_SERVER_ADDR, "mylonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglogin",
                                                                     "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglongpassword"))?;
@@ -73,10 +72,9 @@ fn connect_with_socket_long_username_password_futures_io() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_long_username_password_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
-        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+        let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
         runtime.block_on(Socks5Listener::bind_with_password_and_socket(
             socket,
             ECHO_SERVER_ADDR,

--- a/tests/no_auth.rs
+++ b/tests/no_auth.rs
@@ -47,9 +47,8 @@ fn bind_with_socket_no_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
-    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+    let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
     let conn = runtime.block_on(Socks5Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
     runtime.block_on(futures_utils::test_connect(conn))
 }
@@ -57,10 +56,9 @@ fn connect_with_socket_no_auth_futures_io() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
-        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+        let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
         runtime.block_on(Socks5Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;
     futures_utils::test_bind(bind)

--- a/tests/no_auth.rs
+++ b/tests/no_auth.rs
@@ -49,7 +49,7 @@ fn bind_with_socket_no_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
-    let runtime = runtime().lock().unwrap();
+    let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
     runtime.block_on(futures_utils::test_connect(conn))
@@ -60,7 +60,7 @@ fn connect_with_socket_no_auth_futures_io() -> Result<()> {
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
     let bind = {
-        let runtime = runtime().lock().unwrap();
+        let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
         runtime.block_on(Socks5Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;

--- a/tests/no_auth.rs
+++ b/tests/no_auth.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use tokio_socks::{
-    io::Compat,
     tcp::socks5::{Socks5Listener, Socks5Stream},
     Result,
 };
@@ -45,20 +44,20 @@ fn bind_with_socket_no_auth() -> Result<()> {
     test_bind(bind)
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
     runtime.block_on(futures_utils::test_connect(conn))
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);

--- a/tests/socks4_no_auth.rs
+++ b/tests/socks4_no_auth.rs
@@ -51,7 +51,7 @@ fn bind_with_socket_no_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
-    let runtime = runtime().lock().unwrap();
+    let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
     println!("socket connected");
     let conn = runtime.block_on(Socks4Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
@@ -63,7 +63,7 @@ fn connect_with_socket_no_auth_futures_io() -> Result<()> {
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
     let bind = {
-        let runtime = runtime().lock().unwrap();
+        let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
         runtime.block_on(Socks4Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;

--- a/tests/socks4_no_auth.rs
+++ b/tests/socks4_no_auth.rs
@@ -2,7 +2,12 @@ mod common;
 
 use crate::common::runtime;
 use common::{
-    connect_unix, test_bind_socks4, test_connect, ECHO_SERVER_ADDR, SOCKS4_PROXY_ADDR, UNIX_SOCKS4_PROXY_ADDR,
+    connect_unix,
+    test_bind_socks4,
+    test_connect,
+    ECHO_SERVER_ADDR,
+    SOCKS4_PROXY_ADDR,
+    UNIX_SOCKS4_PROXY_ADDR,
 };
 use tokio_socks::{
     tcp::socks4::{Socks4Listener, Socks4Stream},

--- a/tests/socks4_no_auth.rs
+++ b/tests/socks4_no_auth.rs
@@ -48,9 +48,10 @@ fn bind_with_socket_no_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
-    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+    let socket = runtime
+        .block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?
+        .compat();
     println!("socket connected");
     let conn = runtime.block_on(Socks4Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
     runtime.block_on(futures_utils::test_connect(conn))
@@ -59,10 +60,11 @@ fn connect_with_socket_no_auth_futures_io() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
-        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+        let socket = runtime
+            .block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?
+            .compat();
         runtime.block_on(Socks4Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;
     futures_utils::test_bind_socks4(bind)

--- a/tests/socks4_no_auth.rs
+++ b/tests/socks4_no_auth.rs
@@ -1,9 +1,7 @@
 mod common;
 
-use crate::common::runtime;
 use common::*;
 use tokio_socks::{
-    io::Compat,
     tcp::socks4::{Socks4Listener, Socks4Stream},
     Result,
 };
@@ -47,10 +45,10 @@ fn bind_with_socket_no_auth() -> Result<()> {
     test_bind_socks4(bind)
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_no_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
     println!("socket connected");
@@ -58,10 +56,10 @@ fn connect_with_socket_no_auth_futures_io() -> Result<()> {
     runtime.block_on(futures_utils::test_connect(conn))
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_no_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);

--- a/tests/socks4_no_auth.rs
+++ b/tests/socks4_no_auth.rs
@@ -1,19 +1,14 @@
 mod common;
 
 use crate::common::runtime;
-use common::{
-    connect_unix,
-    test_bind_socks4,
-    test_connect,
-    ECHO_SERVER_ADDR,
-    SOCKS4_PROXY_ADDR,
-    UNIX_SOCKS4_PROXY_ADDR,
-};
+use common::*;
 use tokio_socks::{
+    io::Compat,
     tcp::socks4::{Socks4Listener, Socks4Stream},
     Result,
 };
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_no_auth() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -21,6 +16,7 @@ fn connect_no_auth() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_no_auth() -> Result<()> {
     let bind = {
@@ -30,6 +26,7 @@ fn bind_no_auth() -> Result<()> {
     test_bind_socks4(bind)
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_with_socket_no_auth() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -39,6 +36,7 @@ fn connect_with_socket_no_auth() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_with_socket_no_auth() -> Result<()> {
     let bind = {
@@ -47,4 +45,27 @@ fn bind_with_socket_no_auth() -> Result<()> {
         runtime.block_on(Socks4Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
     }?;
     test_bind_socks4(bind)
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn connect_with_socket_no_auth_futures_io() -> Result<()> {
+    let runtime = runtime().lock().unwrap();
+    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+    println!("socket connected");
+    let conn = runtime.block_on(Socks4Stream::connect_with_socket(socket, ECHO_SERVER_ADDR))?;
+    runtime.block_on(futures_utils::test_connect(conn))
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn bind_with_socket_no_auth_futures_io() -> Result<()> {
+    let bind = {
+        let runtime = runtime().lock().unwrap();
+        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+        runtime.block_on(Socks4Listener::bind_with_socket(socket, ECHO_SERVER_ADDR))
+    }?;
+    futures_utils::test_bind_socks4(bind)
 }

--- a/tests/socks4_userid.rs
+++ b/tests/socks4_userid.rs
@@ -61,7 +61,7 @@ fn bind_with_socket_userid() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_userid_futures_io() -> Result<()> {
-    let runtime = runtime().lock().unwrap();
+    let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks4Stream::connect_with_userid_and_socket(
         socket,
@@ -76,7 +76,7 @@ fn connect_with_socket_userid_futures_io() -> Result<()> {
 #[test]
 fn bind_with_socket_userid_futures_io() -> Result<()> {
     let bind = {
-        let runtime = runtime().lock().unwrap();
+        let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
         runtime.block_on(Socks4Listener::bind_with_user_and_socket(
             socket,

--- a/tests/socks4_userid.rs
+++ b/tests/socks4_userid.rs
@@ -1,7 +1,13 @@
 mod common;
 
 use common::{
-    connect_unix, runtime, test_bind_socks4, test_connect, ECHO_SERVER_ADDR, SOCKS4_PROXY_ADDR, UNIX_SOCKS4_PROXY_ADDR,
+    connect_unix,
+    runtime,
+    test_bind_socks4,
+    test_connect,
+    ECHO_SERVER_ADDR,
+    SOCKS4_PROXY_ADDR,
+    UNIX_SOCKS4_PROXY_ADDR,
 };
 use tokio_socks::{tcp::socks4::*, Result};
 

--- a/tests/socks4_userid.rs
+++ b/tests/socks4_userid.rs
@@ -1,16 +1,9 @@
 mod common;
 
-use common::{
-    connect_unix,
-    runtime,
-    test_bind_socks4,
-    test_connect,
-    ECHO_SERVER_ADDR,
-    SOCKS4_PROXY_ADDR,
-    UNIX_SOCKS4_PROXY_ADDR,
-};
-use tokio_socks::{tcp::socks4::*, Result};
+use common::*;
+use tokio_socks::{io::Compat, tcp::socks4::*, Result};
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_userid() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -22,6 +15,7 @@ fn connect_userid() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_userid() -> Result<()> {
     let bind = {
@@ -35,6 +29,7 @@ fn bind_userid() -> Result<()> {
     test_bind_socks4(bind)
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_with_socket_userid() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -47,6 +42,7 @@ fn connect_with_socket_userid() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_with_socket_userid() -> Result<()> {
     let bind = {
@@ -59,4 +55,34 @@ fn bind_with_socket_userid() -> Result<()> {
         ))
     }?;
     test_bind_socks4(bind)
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn connect_with_socket_userid_futures_io() -> Result<()> {
+    let runtime = runtime().lock().unwrap();
+    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+    let conn = runtime.block_on(Socks4Stream::connect_with_userid_and_socket(
+        socket,
+        ECHO_SERVER_ADDR,
+        "mylogin",
+    ))?;
+    runtime.block_on(futures_utils::test_connect(conn))
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn bind_with_socket_userid_futures_io() -> Result<()> {
+    let bind = {
+        let runtime = runtime().lock().unwrap();
+        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+        runtime.block_on(Socks4Listener::bind_with_user_and_socket(
+            socket,
+            ECHO_SERVER_ADDR,
+            "mylogin",
+        ))
+    }?;
+    futures_utils::test_bind_socks4(bind)
 }

--- a/tests/socks4_userid.rs
+++ b/tests/socks4_userid.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::*;
-use tokio_socks::{io::Compat, tcp::socks4::*, Result};
+use tokio_socks::{tcp::socks4::*, Result};
 
 #[cfg(feature = "tokio")]
 #[test]
@@ -57,10 +57,10 @@ fn bind_with_socket_userid() -> Result<()> {
     test_bind_socks4(bind)
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_userid_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks4Stream::connect_with_userid_and_socket(
@@ -71,10 +71,10 @@ fn connect_with_socket_userid_futures_io() -> Result<()> {
     runtime.block_on(futures_utils::test_connect(conn))
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_userid_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);

--- a/tests/socks4_userid.rs
+++ b/tests/socks4_userid.rs
@@ -60,9 +60,10 @@ fn bind_with_socket_userid() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_userid_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
-    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+    let socket = runtime
+        .block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?
+        .compat();
     let conn = runtime.block_on(Socks4Stream::connect_with_userid_and_socket(
         socket,
         ECHO_SERVER_ADDR,
@@ -74,10 +75,11 @@ fn connect_with_socket_userid_futures_io() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_userid_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
-        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?);
+        let socket = runtime
+            .block_on(futures_utils::connect_unix(UNIX_SOCKS4_PROXY_ADDR))?
+            .compat();
         runtime.block_on(Socks4Listener::bind_with_user_and_socket(
             socket,
             ECHO_SERVER_ADDR,

--- a/tests/username_auth.rs
+++ b/tests/username_auth.rs
@@ -1,11 +1,13 @@
 mod common;
 
-use common::{connect_unix, runtime, test_bind, test_connect, ECHO_SERVER_ADDR, PROXY_ADDR, UNIX_PROXY_ADDR};
+use common::*;
 use tokio_socks::{
+    io::Compat,
     tcp::socks5::{Socks5Listener, Socks5Stream},
     Result,
 };
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_username_auth() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -18,6 +20,7 @@ fn connect_username_auth() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_username_auth() -> Result<()> {
     let bind = {
@@ -32,6 +35,7 @@ fn bind_username_auth() -> Result<()> {
     test_bind(bind)
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn connect_with_socket_username_auth() -> Result<()> {
     let runtime = runtime().lock().unwrap();
@@ -45,6 +49,7 @@ fn connect_with_socket_username_auth() -> Result<()> {
     runtime.block_on(test_connect(conn))
 }
 
+#[cfg(feature = "tokio")]
 #[test]
 fn bind_with_socket_username_auth() -> Result<()> {
     let bind = {
@@ -58,4 +63,36 @@ fn bind_with_socket_username_auth() -> Result<()> {
         ))
     }?;
     test_bind(bind)
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn connect_with_socket_username_auth_futures_io() -> Result<()> {
+    let runtime = runtime().lock().unwrap();
+    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+    let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
+        socket,
+        ECHO_SERVER_ADDR,
+        "mylogin",
+        "mypassword",
+    ))?;
+    runtime.block_on(futures_utils::test_connect(conn))
+}
+
+#[cfg(feature = "tokio")]
+#[cfg(feature = "futures-io")]
+#[test]
+fn bind_with_socket_username_auth_futures_io() -> Result<()> {
+    let bind = {
+        let runtime = runtime().lock().unwrap();
+        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+        runtime.block_on(Socks5Listener::bind_with_password_and_socket(
+            socket,
+            ECHO_SERVER_ADDR,
+            "mylogin",
+            "mypassword",
+        ))
+    }?;
+    futures_utils::test_bind(bind)
 }

--- a/tests/username_auth.rs
+++ b/tests/username_auth.rs
@@ -67,9 +67,8 @@ fn bind_with_socket_username_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_username_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
-    let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+    let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
         socket,
         ECHO_SERVER_ADDR,
@@ -82,10 +81,9 @@ fn connect_with_socket_username_auth_futures_io() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_username_auth_futures_io() -> Result<()> {
-    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
-        let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
+        let socket = runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?.compat();
         runtime.block_on(Socks5Listener::bind_with_password_and_socket(
             socket,
             ECHO_SERVER_ADDR,

--- a/tests/username_auth.rs
+++ b/tests/username_auth.rs
@@ -69,7 +69,7 @@ fn bind_with_socket_username_auth() -> Result<()> {
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_username_auth_futures_io() -> Result<()> {
-    let runtime = runtime().lock().unwrap();
+    let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
         socket,
@@ -85,7 +85,7 @@ fn connect_with_socket_username_auth_futures_io() -> Result<()> {
 #[test]
 fn bind_with_socket_username_auth_futures_io() -> Result<()> {
     let bind = {
-        let runtime = runtime().lock().unwrap();
+        let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
         runtime.block_on(Socks5Listener::bind_with_password_and_socket(
             socket,

--- a/tests/username_auth.rs
+++ b/tests/username_auth.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use tokio_socks::{
-    io::Compat,
     tcp::socks5::{Socks5Listener, Socks5Stream},
     Result,
 };
@@ -65,10 +64,10 @@ fn bind_with_socket_username_auth() -> Result<()> {
     test_bind(bind)
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn connect_with_socket_username_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let runtime = futures_utils::runtime().lock().unwrap();
     let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);
     let conn = runtime.block_on(Socks5Stream::connect_with_password_and_socket(
@@ -80,10 +79,10 @@ fn connect_with_socket_username_auth_futures_io() -> Result<()> {
     runtime.block_on(futures_utils::test_connect(conn))
 }
 
-#[cfg(feature = "tokio")]
 #[cfg(feature = "futures-io")]
 #[test]
 fn bind_with_socket_username_auth_futures_io() -> Result<()> {
+    use tokio_socks::io::Compat;
     let bind = {
         let runtime = futures_utils::runtime().lock().unwrap();
         let socket = Compat::new(runtime.block_on(futures_utils::connect_unix(UNIX_PROXY_ADDR))?);


### PR DESCRIPTION
## Summary
- Added clippy to CI and some clippy fixes.
- Added integration tests for `futures-io` feature using async-std runtime.
- Added `Deref`, `DerefMut`, `pub fn into_inner()` for `Compat<S>`.
- Added `FuturesIoCompatExt` trait with `compat()`, and make `Compat::new` crate private.
- Docs and a README paragraph titled "Compatibility with Other Async Runtimes".

We are now free from `#[cfg(not(feature = "..."))]`.