### PR TITLE
Update CI badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ version = "0.5.2"
 authors = ["Yilin Chen <sticnarf@gmail.com>"]
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "sticnarf/tokio-socks" }
-
 [features]
 default = ["tokio"]
 tor = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tokio-socks
 
-[![Build Status](https://travis-ci.org/sticnarf/tokio-socks.svg?branch=master)](https://travis-ci.org/sticnarf/tokio-socks)
+[![Build Status](https://github.com/sticnarf/tokio-socks/actions/workflows/main.yml/badge.svg)](https://github.com/sticnarf/tokio-socks/actions)
 [![Crates Version](https://img.shields.io/crates/v/tokio-socks.svg)](https://crates.io/crates/tokio-socks)
 [![docs](https://docs.rs/tokio-socks/badge.svg)](https://docs.rs/tokio-socks)
 


### PR DESCRIPTION
- remove `travis_ci` badges from Cargo.toml as it is deprecated: https://docs.rs/cargo_toml/latest/cargo_toml/struct.Badges.html
- change badges in README.md to GitHub workflow status.