### PR TITLE
Replace async-std with smol in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,4 @@ futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["io"] }
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread", "net"] }
 once_cell = "1.2.0"
-hyper = "0.14"
-async-std = "1.12.0"
+smol = "2.0.0"

--- a/src/io/compat.rs
+++ b/src/io/compat.rs
@@ -5,7 +5,7 @@ mod futures;
 ///
 /// Example:
 /// ```no_run
-/// use async_std::os::unix::net::UnixStream;
+/// use smol::net::unix::UnixStream;
 /// use tokio_socks::{io::Compat, tcp::Socks5Stream};
 /// let socket = Compat::new(UnixStream::connect(proxy_addr)
 ///     .await


### PR DESCRIPTION
`async-std` is less actively maintained than the newer `smol`.