### PR TITLE
Use setup-rust-toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,11 @@ jobs:
         rust: [stable, beta, nightly]
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
-          override: true
       - name: Clippy
         run: |
           cargo clippy --all-targets --no-default-features --features=tokio -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [features]
 default = ["tokio"]
 tor = []
-futures-io = ["dep:futures-io"]
 
 [[example]]
 name = "chainproxy"


### PR DESCRIPTION
`actions-rs/toolchain` is not maintained. Use `setup-rust-toolchain` instead.